### PR TITLE
Keep keys in sorted order in node16.

### DIFF
--- a/node4.go
+++ b/node4.go
@@ -70,7 +70,7 @@ func (n *node4) insert(key []byte, value interface{}) node {
 		return n
 	}
 	n16 := newNode16(n)
-	n16.addChildLeaf(key, value)
+	n16.addChildNode(key[0], newNode(key[1:], value))
 	return n16
 }
 


### PR DESCRIPTION
We keep the keys in sorted order, which makes the walk cheaper. We still loop to find children as that's quicker than binary search on just 16 items.
see https://www.superfell.com/weblog/2021/01/it-depends-episode-2 & https://www.superfell.com/weblog/2021/01/it-depends-episode-1

fixes #4 